### PR TITLE
add Handlebars templating to allow hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,23 @@ http://jackdougherty.github.io/leaflet-storymap/index.html
 - Images can be stored in local subfolder or pulled from an external URL.
 - Works in modern browsers: Chrome, Firefox, Safari, Internet Explorer 9+.
 
-### Limitations
-- Due to GeoJSON data limitations, there is no easy way to insert hyperlinks inside the 'description' text. They must be created outside, in fields such as "source-link"
+### HTML template
+See the section labeled `handlebars template` in index.html and adjust the HTML within this [Handlebars template](http://handlebarsjs.com/) as required. 
+
+The variables within this template are injected at run-time via `script.js`:
+
+```
+var output = {
+    "containerId": 'container' + feature.properties['id'],
+    "chapter": feature.properties['chapter'],
+    "imgSrc": feature.properties['image'],
+    "srcHref": feature.properties['source-link'],
+    "srcText": feature.properties['source-credit'],
+    "description": feature.properties['description']
+}
+```
+
+Add corresponding sections to the HTML template and script to add new elements.
 
 ### Compare with
 - Easy-to-learn story map tools -- see Maps Mania 2016 review (http://googlemapsmania.blogspot.com/2016/06/easy-story-maps.html):

--- a/index.html
+++ b/index.html
@@ -34,5 +34,18 @@
 
   <script type="text/javascript" src="script.js"></script>
 
+  <!-- handlebars template for each individual story -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.8/handlebars.min.js"></script>
+  <script id="container-template" type="text/x-handlebars-template">
+    <div id="{{containerId}}" class="image-container">
+      <p class="chapter-header">{{chapter}}</p>
+      <div class="img-holder">
+        <img src="{{imgSrc}}">
+      </div>
+      <a href="{{srcHref}}" target="_blank" class="source">{{srcText}}</a>
+      <p class="description">{{{description}}}</p>
+    </div>
+  </script>
+
 </body>
 </html>

--- a/map.geojson
+++ b/map.geojson
@@ -1,1 +1,79 @@
-{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"id":1,"chapter":"Hartford Public High School 1847","zoom":15,"image":"img/1847-HPHS-Catalog1904p164.jpg","source-credit":"Source: HPHS Quadrennial Catalogue 1904","source-link":"https://www.flickr.com/photos/56513965@N06/21047067205","description":"This scroll-driven storymap is built on an open-source Leaflet template. The design is ideal for telling a story that narrates different locations on a map. Or users can click any marker point to go directly to the chapter narrative."},"geometry":{"type":"Point","coordinates":[-72.6782,41.7676]}},{"type":"Feature","properties":{"id":2,"chapter":"Hartford Public High School 1905","zoom":17,"image":"img/1905-HPHS-postcard.jpg","source-credit":"Source: Flickr","source-link":"https://flic.kr/p/FNxWf8","description":"See directions to create your own storymap. Insert your text, map points, zoom levels, and image links in an easy-to-edit spreadsheet template, named data.csv. Then drag this file into the http://geojson.io tool to convert it into a map file, named data.geojson. "},"geometry":{"type":"Point","coordinates":[-72.6848,41.7677]}},{"type":"Feature","properties":{"id":3,"chapter":"Hartford Public High School 2011","zoom":17,"image":"https://farm6.staticflickr.com/5693/20860554099_1a9466a11e_c.jpg","source-credit":"Source: Carlos Velazquez/Flickr","source-link":"https://flic.kr/p/xMnMXR","description":"Images can be uploaded a local subfolder, or pulled from an external URL (such as this photo on a Flickr server). They are automatically resized to fit into the storymap."},"geometry":{"type":"Point","coordinates":[-72.701,41.7654]}},{"type":"Feature","properties":{"id":4,"chapter":"Bradley Airport, Windsor Locks","zoom":14,"image":"img/BradleyAirport.jpg","source-credit":"Source: public domain/Wikimedia","source-link":"https://commons.wikimedia.org/wiki/File:Airport_2.jpg#/media/File:Airport_2.jpg","description":"The Leafet 1.x code includes a 'fly to' feature that animates the distance traveled from one map point to the next. Users with some coding skills can easily modify the background map, or add map overlays, or extend the code by adding new features."},"geometry":{"type":"Point","coordinates":[-72.687984,41.9387]}},{"type":"Feature","properties":{"id":5,"chapter":"Trinity College, Hartford","zoom":15,"image":"img/TrinityCollege.jpg","source-credit":"Source: Trinity College/edX","source-link":"https://www.edx.org/sites/default/files/trinity1.jpg","description":"To learn how to create your own Leaflet storymap from this template, click on 'View code in GitHub' at the bottom of the map, or go to Leaflet Templates section of the Data Visualization For All book, at http://DataVizForAll.org."},"geometry":{"type":"Point","coordinates":[-72.69,41.747]}}]}
+{
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "properties": {
+            "id": 1,
+            "chapter": "Hartford Public High School 1847",
+            "zoom": 15,
+            "image": "img/1847-HPHS-Catalog1904p164.jpg",
+            "source-credit": "Source: HPHS Quadrennial Catalogue 1904",
+            "source-link": "https://www.flickr.com/photos/56513965@N06/21047067205",
+            "description": "This scroll-driven storymap is built on an <a target='_blank' href='https://github.com/JackDougherty/leaflet-storymap'>open-source Leaflet template</a>. The design is ideal for telling a story that narrates different locations on a map. Or users can click any marker point to go directly to the chapter narrative."
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-72.6782, 41.7676]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "id": 2,
+            "chapter": "Hartford Public High School 1905",
+            "zoom": 17,
+            "image": "img/1905-HPHS-postcard.jpg",
+            "source-credit": "Source: Flickr",
+            "source-link": "https://flic.kr/p/FNxWf8",
+            "description": "See directions to create your own storymap. Insert your text, map points, zoom levels, and image links in an easy-to-edit spreadsheet template, named data.csv. Then drag this file into the http://geojson.io tool to convert it into a map file, named data.geojson. "
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-72.6848, 41.7677]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "id": 3,
+            "chapter": "Hartford Public High School 2011",
+            "zoom": 17,
+            "image": "https://farm6.staticflickr.com/5693/20860554099_1a9466a11e_c.jpg",
+            "source-credit": "Source: Carlos Velazquez/Flickr",
+            "source-link": "https://flic.kr/p/xMnMXR",
+            "description": "Images can be uploaded a local subfolder, or pulled from an external URL (such as this photo on a Flickr server). They are automatically resized to fit into the storymap."
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-72.701, 41.7654]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "id": 4,
+            "chapter": "Bradley Airport, Windsor Locks",
+            "zoom": 14,
+            "image": "img/BradleyAirport.jpg",
+            "source-credit": "Source: public domain/Wikimedia",
+            "source-link": "https://commons.wikimedia.org/wiki/File:Airport_2.jpg#/media/File:Airport_2.jpg",
+            "description": "The Leafet 1.x code includes a 'fly to' feature that animates the distance traveled from one map point to the next. Users with some coding skills can easily modify the background map, or add map overlays, or extend the code by adding new features."
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-72.687984, 41.9387]
+        }
+    }, {
+        "type": "Feature",
+        "properties": {
+            "id": 5,
+            "chapter": "Trinity College, Hartford",
+            "zoom": 15,
+            "image": "img/TrinityCollege.jpg",
+            "source-credit": "Source: Trinity College/edX",
+            "source-link": "https://www.edx.org/sites/default/files/trinity1.jpg",
+            "description": "To learn how to create your own Leaflet storymap from this template, click on 'View code in GitHub' at the bottom of the map, or go to Leaflet Templates section of the <a href='http://DataVizForAll.org' target='_blank'>Data Visualization For All</a> book."
+        },
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-72.69, 41.747]
+        }
+    }]
+}

--- a/script.js
+++ b/script.js
@@ -39,40 +39,19 @@ function initMap() {
           layer.setIcon(numericMarker);
 
           // This creates the contents of each chapter from the GeoJSON data. Unwanted items can be removed, and new ones can be added
-          var chapter = $('<p></p>', {
-            text: feature.properties['chapter'],
-            class: 'chapter-header'
-          });
+          var containerSource = $("#container-template").html();
+          var containerTemplate = Handlebars.compile(containerSource);
 
-          var image = $('<img>', {
-            src: feature.properties['image'],
-          });
-
-          var source = $('<a>', {
-            text: feature.properties['source-credit'],
-            href: feature.properties['source-link'],
-            target: "_blank",
-            class: 'source'
-          });
-
-          var description = $('<p></p>', {
-            text: feature.properties['description'],
-            class: 'description'
-          });
-
-          var container = $('<div></div>', {
-            id: 'container' + feature.properties['id'],
-            class: 'image-container'
-          });
-
-          var imgHolder = $('<div></div', {
-            class: 'img-holder'
-          });
-
-          imgHolder.append(image);
-
-          container.append(chapter).append(imgHolder).append(source).append(description);
-          $('#contents').append(container);
+          var output = {
+            "containerId": 'container' + feature.properties['id'],
+            "chapter": feature.properties['chapter'],
+            "imgSrc": feature.properties['image'],
+            "srcHref": feature.properties['source-link'],
+            "srcText": feature.properties['source-credit'],
+            "description": feature.properties['description']
+          }
+          var html = containerTemplate(output);
+          $('#contents').append(html);
 
           var i;
           var areaTop = -100;

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body {
 }
 
 #contents .space-at-the-bottom {
-    height: 130px;
+    height: 1000px; /* use a large number to ensure the last item is scrollable */
     margin: 0px;
     text-align: center;
     padding-top: 70px;


### PR DESCRIPTION
Thanks for writing this awesome tool!

You mention a limitation on including hyperlinks within the geoJSON description. One option is to use Handlebars templates to insert the HTML blocks programatically, including with valid hyperlinks.

![screen shot 2017-05-05 at 8 02 11 pm](https://cloud.githubusercontent.com/assets/133596/25741375/db7ea39c-31cd-11e7-8631-3f6f8ccb6b3f.png)

